### PR TITLE
Update container to use port 8080 instead of 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,11 @@ RUN mkdir -p /etc/agent-zero/config
 RUN echo '{"whisper": {"enabled": false, "preload": false, "model": null}}' > /etc/agent-zero/config/audio.json
 
 # Expose the web interface port
-EXPOSE 80
+EXPOSE 8080
 
 # Add a healthcheck to monitor container stability
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD curl -f http://localhost/ || exit 1
+  CMD curl -f http://localhost:8080/ || exit 1
 
 # Set the entrypoint with environment variables to ensure Whisper is not loaded
 ENTRYPOINT ["/bin/bash", "-c", "export A0_DISABLE_WHISPER=true A0_SKIP_WHISPER_PRELOAD=true A0_PRELOAD_DISABLED=true && /entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker build -t agent-zero-local .
 
 ```bash
 # Run the container
-docker run -p 50001:80 agent-zero-local
+docker run -p 50001:8080 agent-zero-local
 ```
 
 ## Zeabur Deployment

--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -4,6 +4,6 @@
 docker build -t agent-zero-local .
 
 # Run the container with port mapping
-docker run -d -p 80:80 --name agentzero agent-zero-local
+docker run -d -p 50001:8080 --name agentzero agent-zero-local
 
-echo "Agent Zero is running at http://localhost:80"
+echo "Agent Zero is running at http://localhost:50001"

--- a/zeabur-dockerfile
+++ b/zeabur-dockerfile
@@ -20,11 +20,11 @@ RUN mkdir -p /etc/agent-zero/config && \
     echo '{"whisper": {"enabled": false, "preload": false, "model": null}}' > /etc/agent-zero/config/audio.json
 
 # Expose the web interface port
-EXPOSE 80
+EXPOSE 8080
 
 # Set a healthcheck to help with container stability
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD curl -f http://localhost/ || exit 1
+  CMD curl -f http://localhost:8080/ || exit 1
 
 # Override the entrypoint to ensure our environment variables are set
 ENTRYPOINT ["/bin/bash", "-c", "export A0_DISABLE_WHISPER=true A0_SKIP_WHISPER_PRELOAD=true A0_PRELOAD_DISABLED=true && /entrypoint.sh"]


### PR DESCRIPTION
## Overview

This PR changes the exposed port in the Docker container from port 80 to port 8080. This change ensures better compatibility with common deployment environments where port 80 might be restricted or already in use.

## Changes

- Updated the `Dockerfile` to expose port 8080 instead of 80
- Updated the `zeabur-dockerfile` to expose port 8080 instead of 80
- Modified the `build-and-run.sh` script to map port 50001 to container port 8080
- Updated the healthcheck commands to use port 8080
- Updated the README.md to reflect the port changes in documentation and examples

## Testing

The changes have been tested locally to ensure the container still builds and runs correctly with the new port configuration.

## Deployment Notes

After merging this PR, users should:

1. Pull the latest changes
2. Rebuild their container using the updated Dockerfiles
3. Update any port mappings in their deployment configurations to map to port 8080 instead of 80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the default exposed port from 80 to 8080 in container configurations.
	- Adjusted healthcheck commands to target the new port.
	- Updated documentation and scripts to reflect the new port mapping in usage examples and informational messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->